### PR TITLE
Add umw.edu to list of domains

### DIFF
--- a/lib/domains/edu/umw.txt
+++ b/lib/domains/edu/umw.txt
@@ -1,0 +1,1 @@
+University of Mary Washington


### PR DESCRIPTION
Here is one of multiple examples of long-term programs related to IT offered at the University of Mary Washington: https://www.umw.edu/study/areas/computer-science/

Also, the mail.umw.edu email domain is already included in this repository. That subdomain is used exclusively for students, while faculty use the root domain umw.edu (being submitted now).